### PR TITLE
toLowerCase the dash buttons mac address

### DIFF
--- a/src/DashButton.js
+++ b/src/DashButton.js
@@ -37,7 +37,7 @@ export default class DashButton {
   _isResponding: boolean;
 
   constructor(macAddress: string, options: DashButtonOptions = {}) {
-    this._macAddress = macAddress;
+    this._macAddress = macAddress.toLowerCase();
     this._networkInterface = options.networkInterface ||
       nullthrows(NetworkInterfaces.getDefault());
     this._packetListener = this._handlePacket.bind(this);

--- a/src/__tests__/DashButton-test.js
+++ b/src/__tests__/DashButton-test.js
@@ -23,6 +23,12 @@ describe('DashButton', () => {
     jest.resetModules();
   });
 
+  it(`should normalize (lowercase) the dash buttons Mac Address`, () => {
+    let button = new DashButton('00:11:AA:33:44:BB');
+
+    expect(button._macAddress).toEqual('00:11:aa:33:44:bb');
+  });
+
   it(`creates a pcap session the first time a listener is added`, () => {
     let button = new DashButton(MAC_ADDRESS);
     button.addListener(() => {});


### PR DESCRIPTION
Hey there! 

My Router shows my the mac addresses for my devices in uppercase so it took me a couple of minutes to realize I needed to write them in lowercase :) That the next guy does think "Why doesn't this work" I lower cased the mac address and added a test for it